### PR TITLE
Only show generate button and output in dev mode; adjust plugin window size to 600x400 in prod

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -10,7 +10,7 @@ let generatedScss: string = '';
 // Show the UI with resizable window
 figma.showUI(__html__, {
   width: 600,
-  height: 1200,
+  height: process.env.NODE_ENV === 'development' ? 1200 : 400,
   themeColors: true,
   title: "Eggstractor"
 });

--- a/src/ui.html
+++ b/src/ui.html
@@ -29,13 +29,13 @@
         </select>
       </div>
       <div class="button-group">
-        <button id="generateBtn" class="button">Generate Styles</button>
+        <button id="generateBtn" class="button" style="display: none;">Generate Styles</button>
         <button id="exportTestDataBtn" class="button" style="display: none;">Export Test Data</button>
         <button id="createPRBtn">Create PR</button>
         <span id="status"></span>
       </div>
       <div id="warnings"></div>
-      <div class="output">
+      <div class="output" style="display: none;">
         <pre id="output"></pre>
       </div>
     </div>

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -23,6 +23,11 @@ window.onload = () => {
     if (exportBtn) {
       exportBtn.style.display = 'inline-block';
     }
+    generateBtn.style.display = 'initial';
+    const output = document.querySelector('.output') as HTMLElement;
+    if (output) {
+      output.style.display = 'initial';
+    }
   }
 
   // Save config when inputs change


### PR DESCRIPTION
Dev mode:
<img width="626" alt="Screenshot 2025-03-04 at 3 26 00 PM" src="https://github.com/user-attachments/assets/aa80a10f-23b5-4a4e-9fa0-f3d16708483d" />

Prod mode:
<img width="731" alt="Screenshot 2025-03-04 at 3 26 32 PM" src="https://github.com/user-attachments/assets/af80227a-c541-45c0-84b8-59bd771f162e" />
