### PR TITLE
(PD-583) Borders (Tailwind-SCS)

### DIFF
--- a/src/transformers/tailwind-scss/generators.test.ts
+++ b/src/transformers/tailwind-scss/generators.test.ts
@@ -27,6 +27,7 @@ const basicToken: NonNullableStyleToken = {
 describe("normalizeTailwindToken", () => {
   const whateverRecord: Record<string, string> = {
     "1px": "whatever-1",
+    "this should give DEFAULT": "DEFAULT",
   };
 
   it("should return correct property for given key", () => {
@@ -37,6 +38,14 @@ describe("normalizeTailwindToken", () => {
   it("should return return responsive utility foe given key if no match found", () => {
     const result = normalizeTailwindToken(whateverRecord, "not there");
     expect(result).toBe("[not there]");
+  });
+
+  it("should return an empty string if key is 'DEFAULT'", () => {
+    const result = normalizeTailwindToken(
+      whateverRecord,
+      "this should give DEFAULT"
+    );
+    expect(result).toBe("");
   });
 });
 
@@ -76,6 +85,7 @@ describe("normalizeBorderRadius", () => {
     const result = normalizeBorderRadius("10px");
     expect(result).toEqual(["10px", "10px", "10px", "10px"]);
   });
+
   it("should return a four string array with values sorted in a diagonal layout for border radius when given a string with two values separated by space", () => {
     const result = normalizeBorderRadius("10px 20px");
     expect(result).toEqual(["10px", "20px", "10px", "20px"]);
@@ -122,6 +132,15 @@ describe("generateTailwindBorderClass", () => {
     const result = generateTailwindBorderClass(borderToken);
     expect(result).toBe("border-2 border-solid border-[#0daeff]");
   });
+
+  it("should return 'border' tailwind utility if key given default value", () => {
+    const borderDefaultToken = {
+      ...borderToken,
+      rawValue: "1px solid #0daeff", // "1px" : "DEFAULT" in borderWidths
+    };
+    const result = generateTailwindBorderClass(borderDefaultToken);
+    expect(result).toBe("border border-solid border-[#0daeff]");
+  });
   it("should return tailwind utilities for style and color properly if no width provided", () => {
     const borderTokenNoWidth = {
       ...borderToken,
@@ -152,6 +171,16 @@ describe("generateTailwindBorderRadiusClass", () => {
     expect(result).toBe(
       "rounded-tl-[20px] rounded-tr-[20px] rounded-br-[20px] rounded-bl-[20px]"
     );
+  });
+
+  it("should return tailwind utilities for border radius when given one property", () => {
+    const defaultBorderRadiusToken = {
+      ...basicToken,
+      property: "border-radius",
+      rawValue: "4px", // "1px" : "DEFAULT" in borderRadius
+    };
+    const result = generateTailwindBorderRadiusClass(defaultBorderRadiusToken);
+    expect(result).toBe("rounded-tl rounded-tr rounded-br rounded-bl");
   });
 
   it("should return tailwind utilities for border radius when given two properties", () => {

--- a/src/transformers/tailwind-scss/generators.test.ts
+++ b/src/transformers/tailwind-scss/generators.test.ts
@@ -15,7 +15,7 @@ const basicToken: NonNullableStyleToken = {
   type: "style",
   name: "basic",
   value: "notused 1px",
-  rawValue: "1px",
+  rawValue: "10px",
   valueType: "px",
   property: "blank",
   path: ["basic", "gap"],
@@ -26,13 +26,13 @@ const basicToken: NonNullableStyleToken = {
 
 describe("normalizeTailwindToken", () => {
   const whateverRecord: Record<string, string> = {
-    "1px": "whatever-1",
-    "this should give DEFAULT": "DEFAULT",
+    "5px": "DEFAULT",
+    "10px": "whatever-2",
   };
 
   it("should return correct property for given key", () => {
     const result = normalizeTailwindToken(whateverRecord, basicToken.rawValue);
-    expect(result).toBe("whatever-1");
+    expect(result).toBe("whatever-2");
   });
 
   it("should return return responsive utility foe given key if no match found", () => {
@@ -41,10 +41,7 @@ describe("normalizeTailwindToken", () => {
   });
 
   it("should return an empty string if key is 'DEFAULT'", () => {
-    const result = normalizeTailwindToken(
-      whateverRecord,
-      "this should give DEFAULT"
-    );
+    const result = normalizeTailwindToken(whateverRecord, "5px");
     expect(result).toBe("");
   });
 });

--- a/src/transformers/tailwind-scss/generators.ts
+++ b/src/transformers/tailwind-scss/generators.ts
@@ -78,7 +78,9 @@ export const normalizeTailwindToken = (
   themeMapping: Record<string, string>,
   value: string
 ) => {
-  return themeMapping[value] ?? `[${value}]`;
+  const mapping = themeMapping[value];
+  if (mapping === "DEFAULT") return "";
+  return mapping ?? `[${value}]`;
 };
 
 /*
@@ -145,8 +147,10 @@ export const generateTailwindBorderRadiusClass: Generator = ({ rawValue }) => {
   return normalizeBorderRadius(rawValue)
     .map((v) => (v === "0" ? "0px" : v)) //changing 0 to 0px tailwind utility picks it up
     .map((sizeValue, i) => {
-      const normalizeToken = normalizeTailwindToken(borderRadius, sizeValue);
-      return `rounded-${radiusCorners[i]}-${normalizeToken}`;
+      const normalizedToken = normalizeTailwindToken(borderRadius, sizeValue);
+      return normalizedToken
+        ? `rounded-${radiusCorners[i]}-${normalizedToken}`
+        : `rounded-${radiusCorners[i]}`;
     })
     .join(" ");
 };
@@ -162,11 +166,11 @@ export const generateTailwindBorderClass: Generator = (token) => {
 
   const borderResult: string[] = [];
   if (width) {
+    const normalizedToken = normalizeTailwindToken(borderWidths, width);
     borderResult.push(
-      `${borderPropertyToShorthand[token.property]}-${normalizeTailwindToken(
-        borderWidths,
-        width
-      )}`
+      normalizedToken
+        ? `${borderPropertyToShorthand[token.property]}-${normalizedToken}`
+        : `${borderPropertyToShorthand[token.property]}`
     );
   }
   if (style) {


### PR DESCRIPTION
The implementation didn't properly account for the default values that tailwind utility classes uses, this amends that.