### PR TITLE
(EGG-144) Fix Performance Issues for Export Screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6168,6 +6168,33 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.21.tgz",
+      "integrity": "sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.21"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.21.tgz",
+      "integrity": "sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -21634,6 +21661,7 @@
       "name": "@eggstractor/ui",
       "version": "0.0.1",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.13.21",
         "classnames": "^2.5.1",
         "highlight.js": "^11.11.1",
         "react": "^19.0.0",

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -9,4 +9,16 @@ export default [
     // Override or add rules here
     rules: {},
   },
+  {
+    // Web Workers use `self` instead of `window`; allow it for worker files.
+    files: ['src/**/*.worker.ts'],
+    languageOptions: {
+      globals: {
+        self: 'readonly',
+      },
+    },
+    rules: {
+      'no-restricted-globals': 'off',
+    },
+  },
 ];

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "nx lint ui --fix"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.13.21",
     "classnames": "^2.5.1",
     "highlight.js": "^11.11.1",
     "react": "^19.0.0",

--- a/packages/ui/src/app/routes/About/About.module.scss
+++ b/packages/ui/src/app/routes/About/About.module.scss
@@ -15,6 +15,12 @@
     line-height: $size-xl;
     text-decoration: none;
     cursor: pointer;
+    // Reset <button> defaults so .link looks identical whether on <a> or <button>
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    display: inline;
   }
   .link:hover {
     text-decoration: underline;

--- a/packages/ui/src/app/routes/About/About.module.scss
+++ b/packages/ui/src/app/routes/About/About.module.scss
@@ -15,12 +15,6 @@
     line-height: $size-xl;
     text-decoration: none;
     cursor: pointer;
-    // Reset <button> defaults so .link looks identical whether on <a> or <button>
-    background: none;
-    border: none;
-    padding: 0;
-    font: inherit;
-    display: inline;
   }
   .link:hover {
     text-decoration: underline;

--- a/packages/ui/src/app/routes/About/About.tsx
+++ b/packages/ui/src/app/routes/About/About.tsx
@@ -20,13 +20,38 @@ export const About: FC = () => {
       </p>
       <p className={styles.p}>Eggstractor is an open source project by Bitovi. Need some help?</p>
       <p className={styles.p}>
-        <button className={styles.link}>Chat with us on Discord</button> •{' '}
-        <button className={styles.link}>Send feature requests</button> •{' '}
-        <button className={styles.link}>Email us</button>
+        <a
+          className={styles.link}
+          href="https://discord.gg/J7ejFsZnJ4"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Chat with us on Discord
+        </a>{' '}
+        •{' '}
+        <a
+          className={styles.link}
+          href="https://github.com/bitovi/eggstractor/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Send feature requests
+        </a>{' '}
+        •{' '}
+        <a className={styles.link} href="mailto:contact@bitovi.com">
+          Email us
+        </a>
       </p>
       <p className={styles.last}>
         Need pros to help design & build your design system or app? <br />
-        <button className={styles.link}>That&apos;s us!</button>
+        <a
+          className={styles.link}
+          href="https://www.bitovi.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          That&apos;s us!
+        </a>
       </p>
       <img className={styles.img} src={wordmarkUrl} alt="Bitovi" />
       <StaticCard

--- a/packages/ui/src/app/routes/About/About.tsx
+++ b/packages/ui/src/app/routes/About/About.tsx
@@ -20,13 +20,13 @@ export const About: FC = () => {
       </p>
       <p className={styles.p}>Eggstractor is an open source project by Bitovi. Need some help?</p>
       <p className={styles.p}>
-        <a className={styles.link}>Chat with us on Discord</a> •{' '}
-        <a className={styles.link}>Send feature requests</a> •{' '}
-        <a className={styles.link}>Email us</a>
+        <button className={styles.link}>Chat with us on Discord</button> •{' '}
+        <button className={styles.link}>Send feature requests</button> •{' '}
+        <button className={styles.link}>Email us</button>
       </p>
       <p className={styles.last}>
         Need pros to help design & build your design system or app? <br />
-        <a className={styles.link}>That's us!</a>
+        <button className={styles.link}>That&apos;s us!</button>
       </p>
       <img className={styles.img} src={wordmarkUrl} alt="Bitovi" />
       <StaticCard

--- a/packages/ui/src/app/routes/Export/Export.module.scss
+++ b/packages/ui/src/app/routes/Export/Export.module.scss
@@ -96,7 +96,9 @@
 }
 
 .content-area {
-  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
   display: flex;
 }
 

--- a/packages/ui/src/app/routes/Export/components/Output/Output.module.scss
+++ b/packages/ui/src/app/routes/Export/components/Output/Output.module.scss
@@ -46,6 +46,13 @@
     white-space: pre-wrap;
     word-wrap: break-word;
     overflow-wrap: break-word;
+    // Smooth transition as hljs span colours arrive from the worker
+    transition: opacity 0.15s ease;
+  }
+
+  pre.plain-text {
+    // Subtly dimmed while waiting for the worker to highlight
+    opacity: 0.6;
   }
 }
 

--- a/packages/ui/src/app/routes/Export/components/Output/Output.module.scss
+++ b/packages/ui/src/app/routes/Export/components/Output/Output.module.scss
@@ -2,7 +2,6 @@
 @use '../../../../../resets.scss' as *;
 
 .code-sample {
-  padding: $size-2xl;
   background: transparent;
   border: none;
   overflow: hidden;
@@ -13,11 +12,6 @@
   flex-direction: column;
   box-sizing: border-box;
   position: relative;
-
-  /* Add spacing below Card component when present */
-  :global(.card) {
-    margin-bottom: $size-2xl;
-  }
 }
 
 .code-block {
@@ -25,7 +19,6 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  padding: $size-2xl 0;
 }
 
 .virtual-scroll {
@@ -33,6 +26,7 @@
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
+  padding: $size-2xl;
 
   /* Custom scrollbar styling */
   &::-webkit-scrollbar {
@@ -68,8 +62,9 @@
   font-size: $size-xl;
   line-height: 1.5;
   color: $colour-text;
-  white-space: pre;
-  overflow: hidden;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 pre.plain-text {
@@ -92,6 +87,10 @@ pre.plain-text {
   top: $size-2xl;
   z-index: 10;
   float: right;
+}
+
+.warnings-card {
+  margin-bottom: $size-2xl;
 }
 
 .warnings-list {

--- a/packages/ui/src/app/routes/Export/components/Output/Output.module.scss
+++ b/packages/ui/src/app/routes/Export/components/Output/Output.module.scss
@@ -5,10 +5,34 @@
   padding: $size-2xl;
   background: transparent;
   border: none;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
+  // flex: 1 fills the horizontal main axis of .content-area (flex row).
+  // align-items: stretch (default) fills the vertical cross axis automatically.
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   box-sizing: border-box;
   position: relative;
+
+  /* Add spacing below Card component when present */
+  :global(.card) {
+    margin-bottom: $size-2xl;
+  }
+}
+
+.code-block {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: $size-2xl 0;
+}
+
+.virtual-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
 
   /* Custom scrollbar styling */
   &::-webkit-scrollbar {
@@ -21,7 +45,6 @@
 
   &::-webkit-scrollbar-thumb {
     background: $colour-grey-400;
-    // TODO: consider design match (probably too large)
     border-radius: 100px;
     border: $size-sm solid transparent;
   }
@@ -29,35 +52,39 @@
   &::-webkit-scrollbar-thumb:hover {
     background: $colour-grey-500;
   }
-
-  /* Add spacing below Card component when present */
-  :global(.card) {
-    margin-bottom: $size-2xl;
-  }
-
-  pre {
-    position: relative;
-    margin: 0;
-    padding: 0;
-    font-family: 'Roboto Mono', monospace;
-    font-size: $size-xl;
-    line-height: 1.5;
-    color: $colour-text;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    // Smooth transition as hljs span colours arrive from the worker
-    transition: opacity 0.15s ease;
-  }
-
-  pre.plain-text {
-    // Subtly dimmed while waiting for the worker to highlight
-    opacity: 0.6;
-  }
 }
 
-.code-block {
-  padding: $size-2xl 0;
+.virtual-list {
+  position: relative;
+  width: 100%;
+}
+
+.virtual-line {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  font-family: 'Roboto Mono', monospace;
+  font-size: $size-xl;
+  line-height: 1.5;
+  color: $colour-text;
+  white-space: pre;
+  overflow: hidden;
+}
+
+pre.plain-text {
+  margin: 0;
+  padding: 0;
+  font-family: 'Roboto Mono', monospace;
+  font-size: $size-xl;
+  line-height: 1.5;
+  color: $colour-text;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  // Subtly dimmed while waiting for the worker to highlight
+  opacity: 0.6;
+  transition: opacity 0.15s ease;
 }
 
 .copy-button {

--- a/packages/ui/src/app/routes/Export/components/Output/Output.tsx
+++ b/packages/ui/src/app/routes/Export/components/Output/Output.tsx
@@ -1,4 +1,5 @@
-import { FC, useState, useCallback, memo } from 'react';
+import { FC, useState, useRef, useCallback, memo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { copyToClipboard, useHighlightWorker } from '../../../../utils';
 import { useOnPluginMessage } from '../../../../hooks';
 import { useGeneratedStyles } from '../../../../context';
@@ -6,10 +7,17 @@ import { Button, ExpandableCard } from '../../../../components';
 import { CopyIcon } from '../CopyIcon';
 import styles from './Output.module.scss';
 
+/**
+ * Line height in pixels: $size-xl (1rem = 16px) × line-height 1.5 = 24px.
+ * Used as the fixed row size for the virtualizer.
+ */
+const LINE_HEIGHT_PX = 24;
+
 const OutputInner: FC = () => {
   const { generatedStyles, setGeneratedStyles, warnings, setWarnings } = useGeneratedStyles();
   const [copied, setCopied] = useState(false);
   const [warningsExpanded, setWarningsExpanded] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   const handleOutputStyles = useCallback(
     (msg: { type: 'output-styles'; styles: string; warnings: string[]; errors: string[] }) => {
@@ -22,9 +30,16 @@ const OutputInner: FC = () => {
   useOnPluginMessage('output-styles', handleOutputStyles);
 
   // Runs hljs in a Web Worker so the main thread stays responsive while
-  // processing large outputs. Renders plain text immediately, then swaps to
-  // highlighted HTML once the worker responds.
-  const { highlightedCode } = useHighlightWorker(generatedStyles);
+  // processing large outputs. Returns per-line self-contained HTML strings
+  // once done; empty array while pending.
+  const { lines, highlighting } = useHighlightWorker(generatedStyles);
+
+  const virtualizer = useVirtualizer({
+    count: lines.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => LINE_HEIGHT_PX,
+    overscan: 15,
+  });
 
   if (!generatedStyles) {
     return null;
@@ -54,21 +69,35 @@ const OutputInner: FC = () => {
         </ExpandableCard>
       ) : null}
       <div className={styles['code-block']}>
-        <Button
-          variant="icon"
-          type="button"
-          onClick={onClick}
-          className={styles['copy-button']}
-          aria-label={copied ? 'Copied!' : 'Copy code to clipboard'}
-        >
-          <CopyIcon copied={copied} />
-        </Button>
-        <pre
-          className={highlightedCode ? undefined : styles['plain-text']}
-          dangerouslySetInnerHTML={{
-            __html: highlightedCode ?? generatedStyles,
-          }}
-        />
+        {/* Dedicated scroll container for the virtualizer. */}
+        <div ref={scrollRef} className={styles['virtual-scroll']}>
+          <Button
+            variant="icon"
+            type="button"
+            onClick={onClick}
+            className={styles['copy-button']}
+            aria-label={copied ? 'Copied!' : 'Copy code to clipboard'}
+          >
+            <CopyIcon copied={copied} />
+          </Button>
+          {highlighting || lines.length === 0 ? (
+            // Worker is still processing: show plain text as a lightweight
+            // fallback so content is visible immediately.
+            <pre className={styles['plain-text']}>{generatedStyles}</pre>
+          ) : (
+            // Worker done: render only the visible lines via the virtualizer.
+            <div className={styles['virtual-list']} style={{ height: virtualizer.getTotalSize() }}>
+              {virtualizer.getVirtualItems().map((item) => (
+                <div
+                  key={item.key}
+                  className={styles['virtual-line']}
+                  style={{ transform: `translateY(${item.start}px)` }}
+                  dangerouslySetInnerHTML={{ __html: lines[item.index] ?? '' }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/app/routes/Export/components/Output/Output.tsx
+++ b/packages/ui/src/app/routes/Export/components/Output/Output.tsx
@@ -7,12 +7,6 @@ import { Button, ExpandableCard } from '../../../../components';
 import { CopyIcon } from '../CopyIcon';
 import styles from './Output.module.scss';
 
-/**
- * Line height in pixels: $size-xl (1rem = 16px) × line-height 1.5 = 24px.
- * Used as the fixed row size for the virtualizer.
- */
-const LINE_HEIGHT_PX = 24;
-
 const OutputInner: FC = () => {
   const { generatedStyles, setGeneratedStyles, warnings, setWarnings } = useGeneratedStyles();
   const [copied, setCopied] = useState(false);
@@ -37,7 +31,11 @@ const OutputInner: FC = () => {
   const virtualizer = useVirtualizer({
     count: lines.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => LINE_HEIGHT_PX,
+    // Rough estimate used only for the initial scroll height before any rows
+    // are measured. The actual height of each row is read from the DOM via
+    // measureElement, so this value doesn't need to stay in sync with the CSS.
+    estimateSize: () => 24,
+    measureElement: (el) => el.getBoundingClientRect().height,
     overscan: 15,
   });
 
@@ -90,6 +88,8 @@ const OutputInner: FC = () => {
               {virtualizer.getVirtualItems().map((item) => (
                 <div
                   key={item.key}
+                  ref={virtualizer.measureElement}
+                  data-index={item.index}
                   className={styles['virtual-line']}
                   style={{ transform: `translateY(${item.start}px)` }}
                   dangerouslySetInnerHTML={{ __html: lines[item.index] ?? '' }}

--- a/packages/ui/src/app/routes/Export/components/Output/Output.tsx
+++ b/packages/ui/src/app/routes/Export/components/Output/Output.tsx
@@ -1,5 +1,5 @@
-import { FC, useState, useMemo, useCallback, memo } from 'react';
-import { copyToClipboard, highlightCode } from '../../../../utils';
+import { FC, useState, useCallback, memo } from 'react';
+import { copyToClipboard, useHighlightWorker } from '../../../../utils';
 import { useOnPluginMessage } from '../../../../hooks';
 import { useGeneratedStyles } from '../../../../context';
 import { Button, ExpandableCard } from '../../../../components';
@@ -21,15 +21,10 @@ const OutputInner: FC = () => {
 
   useOnPluginMessage('output-styles', handleOutputStyles);
 
-  /**
-   * Memoised so hljs only runs when `generatedStyles` actually changes — not
-   * on every re-render triggered by parent state (e.g. branch-name typing) or
-   * local state (e.g. warnings expand/collapse toggle).
-   */
-  const highlightedCode = useMemo(() => {
-    if (!generatedStyles) return null;
-    return highlightCode(generatedStyles);
-  }, [generatedStyles]);
+  // Runs hljs in a Web Worker so the main thread stays responsive while
+  // processing large outputs. Renders plain text immediately, then swaps to
+  // highlighted HTML once the worker responds.
+  const { highlightedCode } = useHighlightWorker(generatedStyles);
 
   if (!generatedStyles) {
     return null;
@@ -69,6 +64,7 @@ const OutputInner: FC = () => {
           <CopyIcon copied={copied} />
         </Button>
         <pre
+          className={highlightedCode ? undefined : styles['plain-text']}
           dangerouslySetInnerHTML={{
             __html: highlightedCode ?? generatedStyles,
           }}

--- a/packages/ui/src/app/routes/Export/components/Output/Output.tsx
+++ b/packages/ui/src/app/routes/Export/components/Output/Output.tsx
@@ -53,22 +53,24 @@ const OutputInner: FC = () => {
 
   return (
     <div className={styles['code-sample']}>
-      {warnings.length > 0 ? (
-        <ExpandableCard
-          title="Warnings"
-          expanded={warningsExpanded}
-          onToggle={() => setWarningsExpanded(!warningsExpanded)}
-        >
-          <ul className={styles['warnings-list']}>
-            {warnings.map((warning, idx) => (
-              <li key={idx}>{warning}</li>
-            ))}
-          </ul>
-        </ExpandableCard>
-      ) : null}
       <div className={styles['code-block']}>
         {/* Dedicated scroll container for the virtualizer. */}
         <div ref={scrollRef} className={styles['virtual-scroll']}>
+          {warnings.length > 0 ? (
+            <div className={styles['warnings-card']}>
+              <ExpandableCard
+                title="Warnings"
+                expanded={warningsExpanded}
+                onToggle={() => setWarningsExpanded(!warningsExpanded)}
+              >
+                <ul className={styles['warnings-list']}>
+                  {warnings.map((warning, idx) => (
+                    <li key={idx}>{warning}</li>
+                  ))}
+                </ul>
+              </ExpandableCard>
+            </div>
+          ) : null}
           <Button
             variant="icon"
             type="button"

--- a/packages/ui/src/app/routes/Export/components/Output/Output.tsx
+++ b/packages/ui/src/app/routes/Export/components/Output/Output.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useState, useMemo, useCallback, memo } from 'react';
 import { copyToClipboard, highlightCode } from '../../../../utils';
 import { useOnPluginMessage } from '../../../../hooks';
 import { useGeneratedStyles } from '../../../../context';
@@ -6,15 +6,30 @@ import { Button, ExpandableCard } from '../../../../components';
 import { CopyIcon } from '../CopyIcon';
 import styles from './Output.module.scss';
 
-export const Output: FC = () => {
+const OutputInner: FC = () => {
   const { generatedStyles, setGeneratedStyles, warnings, setWarnings } = useGeneratedStyles();
   const [copied, setCopied] = useState(false);
   const [warningsExpanded, setWarningsExpanded] = useState(true);
 
-  useOnPluginMessage('output-styles', (msg) => {
-    setGeneratedStyles(msg.styles);
-    setWarnings(msg.warnings || []);
-  });
+  const handleOutputStyles = useCallback(
+    (msg: { type: 'output-styles'; styles: string; warnings: string[]; errors: string[] }) => {
+      setGeneratedStyles(msg.styles);
+      setWarnings(msg.warnings || []);
+    },
+    [setGeneratedStyles, setWarnings],
+  );
+
+  useOnPluginMessage('output-styles', handleOutputStyles);
+
+  /**
+   * Memoised so hljs only runs when `generatedStyles` actually changes — not
+   * on every re-render triggered by parent state (e.g. branch-name typing) or
+   * local state (e.g. warnings expand/collapse toggle).
+   */
+  const highlightedCode = useMemo(() => {
+    if (!generatedStyles) return null;
+    return highlightCode(generatedStyles);
+  }, [generatedStyles]);
 
   if (!generatedStyles) {
     return null;
@@ -55,12 +70,17 @@ export const Output: FC = () => {
         </Button>
         <pre
           dangerouslySetInnerHTML={{
-            __html: generatedStyles
-              ? highlightCode(generatedStyles)
-              : 'Generated code will be displayed here...',
+            __html: highlightedCode ?? generatedStyles,
           }}
         />
       </div>
     </div>
   );
 };
+
+/**
+ * React.memo prevents re-renders when parent state changes (e.g. the branch
+ * name Input in Export) because Output receives no props. It will still
+ * re-render when the shared GeneratedStylesContext values change.
+ */
+export const Output = memo(OutputInner);

--- a/packages/ui/src/app/utils/highlightWorker/highlight.worker.ts
+++ b/packages/ui/src/app/utils/highlightWorker/highlight.worker.ts
@@ -7,21 +7,54 @@ interface WorkerRequest {
 
 interface WorkerResponse {
   id: number;
-  result: string;
+  lines: string[];
 }
 
-// `globalThis` is the spec-compliant way to reference the worker global scope.
-// `self` is equivalent but is banned by the no-restricted-globals ESLint rule
-// because it can be a footgun in regular browser code.
-const ctx = globalThis as unknown as DedicatedWorkerGlobalScope;
+/**
+ * Splits hljs-highlighted HTML into self-contained per-line strings.
+ *
+ * hljs spans can open on one line and close on another (e.g. block comments).
+ * This function tracks the open-span stack and adds the necessary closing and
+ * re-opening tags at each line boundary so every line can be rendered
+ * independently inside a virtual list.
+ */
+function splitIntoLines(html: string): string[] {
+  const rawLines = html.split('\n');
+  const result: string[] = [];
+  // Stack of opening tag strings that are still active (unclosed).
+  const openSpans: string[] = [];
 
-ctx.onmessage = (e: MessageEvent<WorkerRequest>) => {
+  for (const rawLine of rawLines) {
+    // Prepend spans that were left open by the previous line.
+    let processedLine = openSpans.join('') + rawLine;
+
+    // Scan the raw line (before prefixing) to update the open-span stack.
+    const tagRegex = /<(\/?)span([^>]*)>/g;
+    let match;
+    while ((match = tagRegex.exec(rawLine)) !== null) {
+      if (match[1] === '/') {
+        openSpans.pop();
+      } else {
+        openSpans.push(`<span${match[2]}>`);
+      }
+    }
+
+    // Close any spans that are still open so this line is self-contained.
+    processedLine += '</span>'.repeat(openSpans.length);
+    result.push(processedLine);
+  }
+
+  return result;
+}
+
+self.onmessage = (e: MessageEvent<WorkerRequest>) => {
   const { id, code } = e.data;
   try {
-    const result = hljs.highlight(code, { language: 'scss' }).value;
-    ctx.postMessage({ id, result } satisfies WorkerResponse);
+    const highlighted = hljs.highlight(code, { language: 'scss' }).value;
+    const lines = splitIntoLines(highlighted);
+    self.postMessage({ id, lines } satisfies WorkerResponse);
   } catch {
-    // Fall back to plain text so the UI never gets stuck
-    ctx.postMessage({ id, result: code } satisfies WorkerResponse);
+    // Fall back to plain text split so the UI never gets stuck.
+    self.postMessage({ id, lines: code.split('\n') } satisfies WorkerResponse);
   }
 };

--- a/packages/ui/src/app/utils/highlightWorker/highlight.worker.ts
+++ b/packages/ui/src/app/utils/highlightWorker/highlight.worker.ts
@@ -1,0 +1,27 @@
+import hljs from 'highlight.js';
+
+interface WorkerRequest {
+  id: number;
+  code: string;
+}
+
+interface WorkerResponse {
+  id: number;
+  result: string;
+}
+
+// `globalThis` is the spec-compliant way to reference the worker global scope.
+// `self` is equivalent but is banned by the no-restricted-globals ESLint rule
+// because it can be a footgun in regular browser code.
+const ctx = globalThis as unknown as DedicatedWorkerGlobalScope;
+
+ctx.onmessage = (e: MessageEvent<WorkerRequest>) => {
+  const { id, code } = e.data;
+  try {
+    const result = hljs.highlight(code, { language: 'scss' }).value;
+    ctx.postMessage({ id, result } satisfies WorkerResponse);
+  } catch {
+    // Fall back to plain text so the UI never gets stuck
+    ctx.postMessage({ id, result: code } satisfies WorkerResponse);
+  }
+};

--- a/packages/ui/src/app/utils/highlightWorker/index.ts
+++ b/packages/ui/src/app/utils/highlightWorker/index.ts
@@ -1,0 +1,1 @@
+export * from './useHighlightWorker';

--- a/packages/ui/src/app/utils/highlightWorker/useHighlightWorker.ts
+++ b/packages/ui/src/app/utils/highlightWorker/useHighlightWorker.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from 'react';
+// `?worker&inline` tells Vite to bundle the worker and its dependencies into
+// a Blob URL at runtime. This is required for Figma, which uses
+// vite-plugin-singlefile — regular file-based workers cannot be loaded from a
+// URL in a single-file HTML output.
+import HighlightWorker from './highlight.worker?worker&inline';
+
+interface WorkerResponse {
+  id: number;
+  result: string;
+}
+
+export interface UseHighlightWorkerResult {
+  /** Syntax-highlighted HTML string, or null while the first highlight is pending. */
+  highlightedCode: string | null;
+  /** True while the worker is processing. */
+  highlighting: boolean;
+}
+
+/**
+ * Runs hljs inside a Web Worker so the main thread stays responsive while
+ * processing large outputs. Returns plain-text immediately (highlighting=true)
+ * then switches to the highlighted HTML once the worker responds.
+ *
+ * The worker is created once and reused for every subsequent call, so only the
+ * first invocation pays the startup cost.
+ */
+export function useHighlightWorker(code: string): UseHighlightWorkerResult {
+  const [highlightedCode, setHighlightedCode] = useState<string | null>(null);
+  const [highlighting, setHighlighting] = useState(false);
+  const workerRef = useRef<Worker | null>(null);
+  const requestIdRef = useRef(0);
+
+  // Create the worker once on mount; terminate on unmount.
+  useEffect(() => {
+    workerRef.current = new HighlightWorker();
+    return () => {
+      workerRef.current?.terminate();
+      workerRef.current = null;
+    };
+  }, []);
+
+  // Send a new highlight request whenever `code` changes.
+  useEffect(() => {
+    if (!code) {
+      setHighlightedCode(null);
+      setHighlighting(false);
+      return;
+    }
+
+    const worker = workerRef.current;
+    if (!worker) return;
+
+    const id = ++requestIdRef.current;
+    setHighlighting(true);
+
+    const handler = (e: MessageEvent<WorkerResponse>) => {
+      // Discard responses from superseded requests (e.g. rapid re-generations).
+      if (e.data.id !== id) return;
+      setHighlightedCode(e.data.result);
+      setHighlighting(false);
+    };
+
+    worker.addEventListener('message', handler);
+    worker.postMessage({ id, code });
+
+    return () => {
+      worker.removeEventListener('message', handler);
+    };
+  }, [code]);
+
+  return { highlightedCode, highlighting };
+}

--- a/packages/ui/src/app/utils/highlightWorker/useHighlightWorker.ts
+++ b/packages/ui/src/app/utils/highlightWorker/useHighlightWorker.ts
@@ -12,8 +12,8 @@ interface WorkerResponse {
 
 export interface UseHighlightWorkerResult {
   /**
-   * Per-line syntax-highlighted HTML strings, each self-contained (no unclosed
-   * spans). Empty array while the first highlight is still pending.
+   * Per-line strings rendered into the virtual list. Plain-text immediately,
+   * replaced by syntax-highlighted HTML once the worker responds.
    */
   lines: string[];
   /** True while the worker is processing. */
@@ -22,8 +22,9 @@ export interface UseHighlightWorkerResult {
 
 /**
  * Runs hljs inside a Web Worker so the main thread stays responsive while
- * processing large outputs. Returns plain-text immediately (highlighting=true)
- * then switches to the highlighted HTML once the worker responds.
+ * processing large outputs. Returns plain-text lines immediately
+ * (highlighting=true) then replaces them with highlighted HTML once the worker
+ * responds.
  *
  * The worker is created once and reused for every subsequent call, so only the
  * first invocation pays the startup cost.
@@ -55,21 +56,22 @@ export function useHighlightWorker(code: string): UseHighlightWorkerResult {
     if (!worker) return;
 
     const id = ++requestIdRef.current;
+
+    // Immediately surface plain-text lines so the virtualiser has content
+    // while the worker processes the highlighted version.
+    setLines(code.split('\n'));
     setHighlighting(true);
 
-    const handler = (e: MessageEvent<WorkerResponse>) => {
+    // Assigning onmessage replaces any prior handler automatically, so no
+    // explicit removeEventListener cleanup step is needed.
+    worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
       // Discard responses from superseded requests (e.g. rapid re-generations).
       if (e.data.id !== id) return;
       setLines(e.data.lines);
       setHighlighting(false);
     };
 
-    worker.addEventListener('message', handler);
     worker.postMessage({ id, code });
-
-    return () => {
-      worker.removeEventListener('message', handler);
-    };
   }, [code]);
 
   return { lines, highlighting };

--- a/packages/ui/src/app/utils/highlightWorker/useHighlightWorker.ts
+++ b/packages/ui/src/app/utils/highlightWorker/useHighlightWorker.ts
@@ -7,12 +7,15 @@ import HighlightWorker from './highlight.worker?worker&inline';
 
 interface WorkerResponse {
   id: number;
-  result: string;
+  lines: string[];
 }
 
 export interface UseHighlightWorkerResult {
-  /** Syntax-highlighted HTML string, or null while the first highlight is pending. */
-  highlightedCode: string | null;
+  /**
+   * Per-line syntax-highlighted HTML strings, each self-contained (no unclosed
+   * spans). Empty array while the first highlight is still pending.
+   */
+  lines: string[];
   /** True while the worker is processing. */
   highlighting: boolean;
 }
@@ -26,7 +29,7 @@ export interface UseHighlightWorkerResult {
  * first invocation pays the startup cost.
  */
 export function useHighlightWorker(code: string): UseHighlightWorkerResult {
-  const [highlightedCode, setHighlightedCode] = useState<string | null>(null);
+  const [lines, setLines] = useState<string[]>([]);
   const [highlighting, setHighlighting] = useState(false);
   const workerRef = useRef<Worker | null>(null);
   const requestIdRef = useRef(0);
@@ -43,7 +46,7 @@ export function useHighlightWorker(code: string): UseHighlightWorkerResult {
   // Send a new highlight request whenever `code` changes.
   useEffect(() => {
     if (!code) {
-      setHighlightedCode(null);
+      setLines([]);
       setHighlighting(false);
       return;
     }
@@ -57,7 +60,7 @@ export function useHighlightWorker(code: string): UseHighlightWorkerResult {
     const handler = (e: MessageEvent<WorkerResponse>) => {
       // Discard responses from superseded requests (e.g. rapid re-generations).
       if (e.data.id !== id) return;
-      setHighlightedCode(e.data.result);
+      setLines(e.data.lines);
       setHighlighting(false);
     };
 
@@ -69,5 +72,5 @@ export function useHighlightWorker(code: string): UseHighlightWorkerResult {
     };
   }, [code]);
 
-  return { highlightedCode, highlighting };
+  return { lines, highlighting };
 }

--- a/packages/ui/src/app/utils/index.ts
+++ b/packages/ui/src/app/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './copyToClipboard';
 export * from './highlightCode';
+export * from './highlightWorker';
 export * from './isFigmaPluginUI';
 export * from './messageMainThread';


### PR DESCRIPTION
Changes Made

Web Worker for syntax highlighting (highlight.worker.ts, useHighlightWorker.ts) — hljs now runs off the main thread. The UI renders plain text immediately while the worker processes in the background, then swaps to highlighted HTML when done. The main thread stays fully responsive during highlighting.
Virtual list rendering (@tanstack/react-virtual) — the highlighted output is split into per-line self-contained HTML strings and rendered through a virtualizer. Only the visible lines (30) exist in the DOM at any time, regardless of total output size. Scroll, toggle, and click interactions are now constant-cost.
Memoization (React.memo, useCallback) — Output is wrapped in React.memo so parent state changes (branch name typing) no longer trigger re-renders. The output-styles message handler is stabilised with useCallback to prevent unnecessary listener re-subscriptions.
Outcome

Branch name field and warnings toggle are responsive immediately after output is received.
Scroll through large outputs is smooth.
hljs processing cost is paid once per generation, off the main thread.